### PR TITLE
Remove Opera from Selenium module

### DIFF
--- a/modules/selenium/src/main/java/org/shakespeareframework/selenium/BrowserType.java
+++ b/modules/selenium/src/main/java/org/shakespeareframework/selenium/BrowserType.java
@@ -9,7 +9,6 @@ import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.edge.EdgeOptions;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.ie.InternetExplorerOptions;
-import org.openqa.selenium.opera.OperaOptions;
 import org.openqa.selenium.safari.SafariOptions;
 
 /** {@link Enum} of all browser types which are supported by {@link WebDriverSupplier}. */
@@ -20,9 +19,6 @@ public enum BrowserType {
 
   /** Mozilla Firefox */
   FIREFOX(org.openqa.selenium.firefox.FirefoxDriver.class, new FirefoxOptions()),
-
-  /** Opera */
-  OPERA(org.openqa.selenium.opera.OperaDriver.class, new OperaOptions()),
 
   /** Microsoft Edge */
   EDGE(org.openqa.selenium.edge.EdgeDriver.class, new EdgeOptions()),

--- a/modules/selenium/src/test/java/org/shakespeareframework/selenium/BrowserTypeTest.java
+++ b/modules/selenium/src/test/java/org/shakespeareframework/selenium/BrowserTypeTest.java
@@ -13,7 +13,6 @@ class BrowserTypeTest {
       strings = {
         "chrome", "CHROME", "Chrome",
         "firefox", "FIREFOX", "Firefox",
-        "opera", "OPERA", "Opera",
         "edge", "EDGE", "Edge",
         "iexplorer", "IEXPLORER", "IExplorer"
       })

--- a/modules/selenium/src/test/java/org/shakespeareframework/selenium/DockerWebDriverSupplierTest.java
+++ b/modules/selenium/src/test/java/org/shakespeareframework/selenium/DockerWebDriverSupplierTest.java
@@ -13,7 +13,7 @@ class DockerWebDriverSupplierTest {
   @ParameterizedTest(name = "get works for {0}")
   @EnumSource(
       value = BrowserType.class,
-      names = {"CHROME", "FIREFOX", "EDGE", "OPERA", "SAFARI"})
+      names = {"CHROME", "FIREFOX", "EDGE", "SAFARI"})
   void getTest1(BrowserType browserType) throws IOException, InterruptedException {
     assumeThat(new ProcessBuilder("which", "docker").start().waitFor()).isEqualTo(0);
 


### PR DESCRIPTION
Since selenium-java 4.1.3 OperaDriver and OperaOptions are deprecated.

See https://github.com/SeleniumHQ/selenium/blob/trunk/java/CHANGELOG

Fixes
https://sonarcloud.io/project/issues?issues=AX_bDM8o_b8s2FQ3EIOV&open=AX_bDM8o_b8s2FQ3EIOV&id=mkutz_shakespeare
and
https://sonarcloud.io/project/issues?issues=AX_bDM8o_b8s2FQ3EIOW&open=AX_bDM8o_b8s2FQ3EIOW&id=mkutz_shakespeare

Closes #128
