### PR TITLE
Fix too long filenames in FileReporter

### DIFF
--- a/modules/core/src/main/java/org/shakespeareframework/reporting/FileReporter.java
+++ b/modules/core/src/main/java/org/shakespeareframework/reporting/FileReporter.java
@@ -30,6 +30,15 @@ public abstract class FileReporter implements Reporter {
    * Writes the given content to a new file in the {@link #reportsPath}. The {@link #reportsPath} is
    * automatically created if necessary.
    *
+   * <p>The filename will be structured as follows:
+   *
+   * <p><code>
+   * [increased {@link #counter} with leading zeros]-[{@link Actor#getName() actor.name}]-
+   * [{@link ReportType reportType}]-[activity].[fileNameExtension]
+   * </code>
+   *
+   * <p>E.g. <code>001-fiona-start-some_question.txt</code>
+   *
    * @param actor the acting {@link Actor}
    * @param reportType the {@link ReportType}
    * @param activity the {@link org.shakespeareframework.Task} or {@link
@@ -53,11 +62,11 @@ public abstract class FileReporter implements Reporter {
     final var reportPath =
         reportsPath.resolve(
             format(
-                "%03d-%s-%s-%s.%s",
+                "%03d-%.20s-%.7s-%.100s.%10s",
                 ++counter,
                 actor.getName().toLowerCase(Locale.ROOT),
                 reportType,
-                activity.toString().replaceAll("[^\\w]+", "_"),
+                activity.toString().replaceAll("\\W+", "_"),
                 fileNameExtension));
     try {
       write(reportPath, content, CREATE, TRUNCATE_EXISTING);

--- a/modules/core/src/main/java/org/shakespeareframework/reporting/FileReporter.java
+++ b/modules/core/src/main/java/org/shakespeareframework/reporting/FileReporter.java
@@ -62,7 +62,7 @@ public abstract class FileReporter implements Reporter {
     final var reportPath =
         reportsPath.resolve(
             format(
-                "%03d-%.20s-%.7s-%.100s.%10s",
+                "%03d-%.20s-%.7s-%.100s.%.10s",
                 ++counter,
                 actor.getName().toLowerCase(Locale.ROOT),
                 reportType,

--- a/modules/core/src/test/java/org/shakespeareframework/reporting/FileReporterTest.java
+++ b/modules/core/src/test/java/org/shakespeareframework/reporting/FileReporterTest.java
@@ -93,6 +93,26 @@ class FileReporterTest {
             "glob:build/reports/shakespeare/006-fiona-failure-some_question.txt");
   }
 
+  @Test
+  @DisplayName("file names parts are shortened")
+  void test4() {
+    var testFileReporter = new TestFileReporter(reportsPath);
+    var longString = "abcdefghijklmnopqrstuvwxyz".repeat(10);
+    var taskWithLongToString = new TestTaskBuilder().string(longString).build();
+    var actorWithLongName = new Actor(longString);
+
+    testFileReporter.start(actorWithLongName, taskWithLongToString);
+
+    assertThat(reportsPath)
+        .exists()
+        .isDirectoryContaining(
+            "regex:build/reports/shakespeare/"
+                + "(\\d{3})-([a-z]{20})-"
+                + "(start|retry|success|failure)-"
+                + "([a-z]{100})."
+                + "(txt)");
+  }
+
   private static class TestFileReporter extends FileReporter {
 
     protected TestFileReporter(Path reportsDirectory) {

--- a/modules/core/src/test/java/org/shakespeareframework/reporting/FileReporterTest.java
+++ b/modules/core/src/test/java/org/shakespeareframework/reporting/FileReporterTest.java
@@ -107,7 +107,8 @@ class FileReporterTest {
         .exists()
         .isDirectoryContaining(
             "regex:build/reports/shakespeare/"
-                + "(\\d{3})-([a-z]{20})-"
+                + "(\\d{3})-"
+                + "([a-z]{20})-"
                 + "(start|retry|success|failure)-"
                 + "([a-z]{100})."
                 + "(txt)");


### PR DESCRIPTION
Filenames could be indefinitely long (due to activity toString and actor
names). This should be reduced to not exceed 255 charters in total,
which causes an exception.

This limits the length of the author name to 20 and the activity
toString to 100.

The total length is now

```
  3+1 for counter and separator,
+ 6/7+1 for report type and separator,
+ 100+1 for activity and separator,
+ 10 for filename extension
= 123 max characters
```

Closes #133