### PR TITLE
Allow predicate in retryable task/question

### DIFF
--- a/modules/core/src/main/java/org/shakespeareframework/Actor.java
+++ b/modules/core/src/main/java/org/shakespeareframework/Actor.java
@@ -92,8 +92,7 @@ public final class Actor {
         return this;
       } catch (Exception e) {
         lastException = e;
-        if (task.getAcknowledgedExceptions().stream()
-            .anyMatch(acknowledge -> acknowledge.isInstance(e))) {
+        if (task.isAcknowledgedException(e)) {
           reporters.forEach(reporter -> reporter.failure(this, task, e));
           throw e;
         }
@@ -163,7 +162,7 @@ public final class Actor {
         reporters.forEach(reporter -> reporter.retry(this, question, answer));
       } catch (Exception e) {
         lastException = e;
-        if (question.getIgnoredExceptions().stream().noneMatch(ignore -> ignore.isInstance(e))) {
+        if (question.isIgnoredException(e)) {
           reporters.forEach(reporter -> reporter.failure(this, question, e));
           throw e;
         }

--- a/modules/core/src/main/java/org/shakespeareframework/RetryableQuestion.java
+++ b/modules/core/src/main/java/org/shakespeareframework/RetryableQuestion.java
@@ -8,7 +8,7 @@ import java.util.Set;
 /**
  * A {@link Question} that will be retried until it yields an answer deemed {@link #acceptable} or
  * the {@link Retryable#getTimeout() timeout} is reached. {@link Exception}s thrown will be ignored
- * if they are contained in {@link #getIgnoredExceptions() ignoredExceptions}.
+ * if they match the {@link #isIgnoredException(Exception) isIgnoredException predicate}.
  */
 public interface RetryableQuestion<A> extends Question<A>, Retryable {
 
@@ -18,6 +18,13 @@ public interface RetryableQuestion<A> extends Question<A>, Retryable {
    */
   default Set<Class<? extends Exception>> getIgnoredExceptions() {
     return Set.of();
+  }
+
+  /**
+   * @return the predicate that decides weather the exception will be ignored when thrown in a retry
+   */
+  default boolean isIgnoredException(Exception exception) {
+    return getIgnoredExceptions().stream().noneMatch(ignored -> ignored.isInstance(exception));
   }
 
   /**

--- a/modules/core/src/main/java/org/shakespeareframework/RetryableTask.java
+++ b/modules/core/src/main/java/org/shakespeareframework/RetryableTask.java
@@ -4,8 +4,8 @@ import java.util.Set;
 
 /**
  * A {@link Task} that will be retried until it succeeds or the {@link Retryable#getTimeout()
- * timeout} is reached. {@link Exception}s thrown will be ignored by default unless they are
- * contained in the {@link #getAcknowledgedExceptions() acknowledgedExceptions}.
+ * timeout} is reached. {@link Exception}s thrown will be ignored by default unless they match
+ * {@link #isAcknowledgedException(Exception) the acknowledged exception predicate}.
  */
 public interface RetryableTask extends Task, Retryable {
 
@@ -15,5 +15,14 @@ public interface RetryableTask extends Task, Retryable {
    */
   default Set<Class<? extends Exception>> getAcknowledgedExceptions() {
     return Set.of();
+  }
+
+  /**
+   * @return the predicate that decides weather the exception won't be ignored when thrown in a
+   *     retry
+   */
+  default boolean isAcknowledgedException(Exception exception) {
+    return getAcknowledgedExceptions().stream()
+        .anyMatch(acknowledge -> acknowledge.isInstance(exception));
   }
 }


### PR DESCRIPTION
There are cases where the class of an exception isn't sufficient to decide weather it should be ignored or not.